### PR TITLE
Add short report variant and shared print styling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import '../report/report.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,20 +13,44 @@ export default function Home() {
       <h1 style={{ fontSize: '2rem', fontWeight: 'bold', marginBottom: '2rem' }}>
         SkillTier Reports
       </h1>
-      <Link
-        href="/report-demo"
+      <div
         style={{
-          display: 'inline-block',
-          padding: '1rem 2rem',
-          backgroundColor: '#7B61FF',
-          color: '#fff',
-          borderRadius: '6px',
-          textDecoration: 'none',
-          fontWeight: '600',
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '1rem',
+          flexWrap: 'wrap',
         }}
       >
-        View Long Report Demo
-      </Link>
+        <Link
+          href="/report-demo"
+          style={{
+            display: 'inline-block',
+            padding: '1rem 2rem',
+            backgroundColor: '#7B61FF',
+            color: '#fff',
+            borderRadius: '6px',
+            textDecoration: 'none',
+            fontWeight: '600',
+          }}
+        >
+          View Long Report Demo
+        </Link>
+        <Link
+          href="/short-report-demo"
+          style={{
+            display: 'inline-block',
+            padding: '1rem 2rem',
+            backgroundColor: '#1E1F25',
+            color: '#E6E8EC',
+            borderRadius: '6px',
+            textDecoration: 'none',
+            fontWeight: '600',
+            border: '1px solid #7B61FF',
+          }}
+        >
+          View Short Report Demo
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/report-demo/page.tsx
+++ b/app/report-demo/page.tsx
@@ -6,18 +6,6 @@ import { sampleData } from '@/report/sampleData';
 export default function ReportDemoPage() {
   return (
     <div className="min-h-screen bg-[#0D0E12]">
-      <style jsx global>{`
-        @media print {
-          @page {
-            size: A4;
-            margin: 0;
-          }
-          body {
-            margin: 0;
-            padding: 0;
-          }
-        }
-      `}</style>
       <LongReportDemo doc={sampleData} />
     </div>
   );

--- a/app/reports/[id]/page.tsx
+++ b/app/reports/[id]/page.tsx
@@ -1,21 +1,26 @@
+import { notFound } from 'next/navigation';
+
 import { LongReportDemo } from '@/report/long/LongReportDemo';
 import { ShortPage } from '@/report/short/ShortPage';
 import { sampleData } from '@/report/sampleData';
+import type { ReportDocT } from '@/report/types/report';
 
 interface ReportPageProps {
   params: { id: string };
-  searchParams: { variant?: string };
+  searchParams: { variant?: string; demo?: string };
 }
 
 export default function ReportPage({ searchParams }: ReportPageProps) {
-  const doc = sampleData; // TODO: replace with real data fetch when available
+  const variant = searchParams?.variant === 'short' ? 'short' : 'long';
+  const isDemo = searchParams?.demo === '1';
+  const doc: ReportDocT | null = isDemo ? sampleData : null;
 
-  if (searchParams?.variant === 'short') {
-    return (
-      <div className="min-h-screen bg-[#0D0E12] flex items-center justify-center py-10">
-        <ShortPage doc={doc} />
-      </div>
-    );
+  if (!doc) {
+    notFound();
+  }
+
+  if (variant === 'short') {
+    return <ShortPage doc={doc} />;
   }
 
   return (

--- a/app/reports/[id]/page.tsx
+++ b/app/reports/[id]/page.tsx
@@ -1,0 +1,26 @@
+import { LongReportDemo } from '@/report/long/LongReportDemo';
+import { ShortPage } from '@/report/short/ShortPage';
+import { sampleData } from '@/report/sampleData';
+
+interface ReportPageProps {
+  params: { id: string };
+  searchParams: { variant?: string };
+}
+
+export default function ReportPage({ searchParams }: ReportPageProps) {
+  const doc = sampleData; // TODO: replace with real data fetch when available
+
+  if (searchParams?.variant === 'short') {
+    return (
+      <div className="min-h-screen bg-[#0D0E12] flex items-center justify-center py-10">
+        <ShortPage doc={doc} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0D0E12]">
+      <LongReportDemo doc={doc} />
+    </div>
+  );
+}

--- a/app/short-report-demo/page.tsx
+++ b/app/short-report-demo/page.tsx
@@ -2,9 +2,5 @@ import { ShortPage } from '@/report/short/ShortPage';
 import { sampleData } from '@/report/sampleData';
 
 export default function ShortReportDemoPage() {
-  return (
-    <div className="min-h-screen bg-[#0D0E12] flex items-center justify-center py-10">
-      <ShortPage doc={sampleData} />
-    </div>
-  );
+  return <ShortPage doc={sampleData} />;
 }

--- a/app/short-report-demo/page.tsx
+++ b/app/short-report-demo/page.tsx
@@ -1,0 +1,10 @@
+import { ShortPage } from '@/report/short/ShortPage';
+import { sampleData } from '@/report/sampleData';
+
+export default function ShortReportDemoPage() {
+  return (
+    <div className="min-h-screen bg-[#0D0E12] flex items-center justify-center py-10">
+      <ShortPage doc={sampleData} />
+    </div>
+  );
+}

--- a/report/report.css
+++ b/report/report.css
@@ -1,0 +1,107 @@
+@media print {
+  @page {
+    size: A4;
+    margin: 0;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+:root {
+  --report-accent: #7B61FF;
+}
+
+.page {
+  width: 210mm;
+  height: 297mm;
+  page-break-after: always;
+}
+
+.short-report {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  column-gap: 4mm;
+  row-gap: 4mm;
+  padding: 12mm;
+  background: #0d0e12;
+  color: #e6e8ec;
+  box-sizing: border-box;
+  font-family: 'Inter', sans-serif;
+}
+
+.short-report a,
+.short-report button,
+.short-report [tabindex] {
+  outline: none;
+}
+
+.short-report-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 6mm;
+  padding: 4mm;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-sizing: border-box;
+}
+
+.short-report-card:focus,
+.short-report-card:focus-within {
+  border-color: var(--report-accent);
+  box-shadow: 0 0 0 1.2px var(--report-accent);
+}
+
+.short-report-muted {
+  color: #9ba1a6;
+}
+
+.clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.short-report-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3mm;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.short-report-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 2mm;
+}
+
+.short-report-list li::before {
+  content: '';
+}
+
+.short-report-footer {
+  text-align: center;
+  font-size: 10pt;
+  color: #9ba1a6;
+}
+
+.short-report-cta {
+  background: rgba(123, 97, 255, 0.08);
+  border: 1px solid rgba(123, 97, 255, 0.4);
+  color: #e6e8ec;
+  border-radius: 6mm;
+  padding: 3mm 4mm;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}

--- a/report/report.css
+++ b/report/report.css
@@ -52,6 +52,17 @@
   box-shadow: 0 0 0 1.2px var(--report-accent);
 }
 
+.short-report-mini-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2mm;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 4mm;
+  padding: 3mm;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-sizing: border-box;
+}
+
 .short-report-muted {
   color: #9ba1a6;
 }

--- a/report/sampleData.ts
+++ b/report/sampleData.ts
@@ -1,6 +1,6 @@
-import { ReportData } from './types/report';
+import type { ReportDocT } from './types/report';
 
-export const sampleData: ReportData = {
+export const sampleData: ReportDocT = {
   name: 'Jordan Chen',
   date: '2025-10-01',
   overall: {

--- a/report/short/ShortPage.tsx
+++ b/report/short/ShortPage.tsx
@@ -2,7 +2,7 @@ import { TierBadge } from '../atoms/TierBadge';
 import { RarityTag } from '../atoms/RarityTag';
 import { RadarSVG } from '../atoms/RadarSVG';
 import { Bar } from '../atoms/Bar';
-import { ReportData as ReportDocT } from '../types/report';
+import type { ReportDocT } from '../types/report';
 
 interface ShortPageProps {
   doc: ReportDocT;
@@ -33,16 +33,16 @@ export function ShortPage({ doc }: ShortPageProps) {
             gridColumn: '1 / span 7',
             display: 'flex',
             flexDirection: 'column',
-            justifyContent: 'space-between',
-            gap: '3mm',
+            justifyContent: 'center',
+            gap: '2.5mm',
           }}
         >
-          <div style={{ fontSize: '14pt', fontWeight: 700 }}>SkillTier — Short Report</div>
-          <div className="short-report-muted" style={{ fontSize: '10pt' }}>
-            {doc.date}
+          <div style={{ fontSize: '14pt', fontWeight: 700, letterSpacing: '0.4px' }}>
+            SkillTier — Short Report
           </div>
-          <div className="short-report-muted clamp-2" style={{ fontSize: '11pt', maxWidth: '90mm' }}>
-            Snapshot of the SkillTier cognitive profile condensed into a single actionable sheet.
+          <div style={{ fontSize: '20pt', fontWeight: 700, lineHeight: 1.2 }}>{doc.name}</div>
+          <div className="short-report-muted" style={{ fontSize: '10pt', letterSpacing: '0.3px' }}>
+            {doc.date}
           </div>
         </div>
 
@@ -63,15 +63,20 @@ export function ShortPage({ doc }: ShortPageProps) {
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '2mm' }}>
               <div style={{ fontSize: '32pt', fontWeight: 700, lineHeight: 1 }}>{doc.overall.score}</div>
-              <div className="short-report-muted" style={{ fontSize: '10pt' }}>
+              <div className="short-report-muted" style={{ fontSize: '10pt', letterSpacing: '0.3px' }}>
                 Score
               </div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '2mm' }}>
               <TierBadge tier={doc.overall.tier} />
               <RarityTag rarity={doc.overall.rarity} />
-              <div className="short-report-muted" style={{ fontSize: '10pt' }}>
-                Top {doc.overall.percentile}% percentile
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '0.5mm' }}>
+                <div style={{ fontSize: '14pt', fontWeight: 700, lineHeight: 1 }}>
+                  Top {doc.overall.percentile}%
+                </div>
+                <div className="short-report-muted" style={{ fontSize: '9pt', letterSpacing: '0.3px' }}>
+                  Percentile
+                </div>
               </div>
             </div>
           </div>
@@ -119,10 +124,7 @@ export function ShortPage({ doc }: ShortPageProps) {
           tabIndex={0}
         >
           {doc.domains.map((domain) => (
-            <div
-              key={domain.domain}
-              style={{ display: 'flex', flexDirection: 'column', gap: '2mm' }}
-            >
+            <div key={domain.domain} className="short-report-mini-card">
               <div style={{ display: 'flex', flexDirection: 'column', gap: '1mm' }}>
                 <div style={{ fontSize: '10pt', fontWeight: 600 }}>{formatDomainName(domain.domain)}</div>
                 <TierBadge tier={domain.tier} size="sm" />

--- a/report/short/ShortPage.tsx
+++ b/report/short/ShortPage.tsx
@@ -1,0 +1,199 @@
+import { TierBadge } from '../atoms/TierBadge';
+import { RarityTag } from '../atoms/RarityTag';
+import { RadarSVG } from '../atoms/RadarSVG';
+import { Bar } from '../atoms/Bar';
+import { ReportData as ReportDocT } from '../types/report';
+
+interface ShortPageProps {
+  doc: ReportDocT;
+}
+
+const formatDomainName = (domain: string) =>
+  domain.length === 0 ? domain : domain.charAt(0).toUpperCase() + domain.slice(1);
+
+export function ShortPage({ doc }: ShortPageProps) {
+  const domainValues = doc.domains.map((domain) => domain.score);
+  const domainLabels = doc.domains.map((domain) => formatDomainName(domain.domain));
+  const trapsText = doc.traps.join(' • ');
+
+  return (
+    <div className="page short-report">
+      <header
+        style={{
+          gridColumn: '1 / span 12',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+          columnGap: '4mm',
+          rowGap: '4mm',
+          alignItems: 'stretch',
+        }}
+      >
+        <div
+          style={{
+            gridColumn: '1 / span 7',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            gap: '3mm',
+          }}
+        >
+          <div style={{ fontSize: '14pt', fontWeight: 700 }}>SkillTier — Short Report</div>
+          <div className="short-report-muted" style={{ fontSize: '10pt' }}>
+            {doc.date}
+          </div>
+          <div className="short-report-muted clamp-2" style={{ fontSize: '11pt', maxWidth: '90mm' }}>
+            Snapshot of the SkillTier cognitive profile condensed into a single actionable sheet.
+          </div>
+        </div>
+
+        <div
+          className="short-report-card"
+          style={{
+            gridColumn: '8 / span 5',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '3mm',
+            justifyContent: 'space-between',
+          }}
+          tabIndex={0}
+        >
+          <div className="short-report-muted" style={{ fontSize: '9pt', letterSpacing: '0.5px' }}>
+            OVERALL SNAPSHOT
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '2mm' }}>
+              <div style={{ fontSize: '32pt', fontWeight: 700, lineHeight: 1 }}>{doc.overall.score}</div>
+              <div className="short-report-muted" style={{ fontSize: '10pt' }}>
+                Score
+              </div>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '2mm' }}>
+              <TierBadge tier={doc.overall.tier} />
+              <RarityTag rarity={doc.overall.rarity} />
+              <div className="short-report-muted" style={{ fontSize: '10pt' }}>
+                Top {doc.overall.percentile}% percentile
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section
+        style={{
+          gridColumn: '1 / span 12',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+          columnGap: '4mm',
+        }}
+      >
+        <div
+          className="short-report-card"
+          style={{
+            gridColumn: '1 / span 5',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '3mm',
+          }}
+          tabIndex={0}
+        >
+          <div className="short-report-muted" style={{ fontSize: '9pt', letterSpacing: '0.5px' }}>
+            DOMAIN RADAR
+          </div>
+          <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+            <RadarSVG values={domainValues} labels={domainLabels} />
+          </div>
+        </div>
+
+        <div
+          className="short-report-card"
+          style={{
+            gridColumn: '6 / span 7',
+            display: 'grid',
+            gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+            columnGap: '4mm',
+            rowGap: '4mm',
+            padding: '4mm',
+          }}
+          tabIndex={0}
+        >
+          {doc.domains.map((domain) => (
+            <div
+              key={domain.domain}
+              style={{ display: 'flex', flexDirection: 'column', gap: '2mm' }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '1mm' }}>
+                <div style={{ fontSize: '10pt', fontWeight: 600 }}>{formatDomainName(domain.domain)}</div>
+                <TierBadge tier={domain.tier} size="sm" />
+              </div>
+              <div style={{ fontSize: '18pt', fontWeight: 700, lineHeight: 1 }}>{domain.score}</div>
+              <Bar label="Score" value={domain.score} showValue={false} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
+        style={{
+          gridColumn: '1 / span 12',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+          columnGap: '4mm',
+        }}
+      >
+        <div
+          className="short-report-card"
+          style={{
+            gridColumn: '1 / span 6',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '3mm',
+          }}
+          tabIndex={0}
+        >
+          <div style={{ fontSize: '11pt', fontWeight: 600 }}>Hidden potentials</div>
+          <ul className="short-report-list">
+            {doc.undervalued.map((item) => (
+              <li key={item.domain}>
+                <div style={{ fontSize: '10pt', fontWeight: 600 }}>{item.domain}</div>
+                <div className="short-report-muted clamp-3" style={{ fontSize: '9pt', lineHeight: 1.4 }}>
+                  {item.why}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div
+          className="short-report-card"
+          style={{
+            gridColumn: '7 / span 6',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '3mm',
+          }}
+          tabIndex={0}
+        >
+          <div style={{ fontSize: '11pt', fontWeight: 600 }}>Risks</div>
+          <div className="short-report-muted clamp-3" style={{ fontSize: '10pt', lineHeight: 1.5 }}>
+            {trapsText}
+          </div>
+        </div>
+      </section>
+
+      <div
+        style={{
+          gridColumn: '1 / span 12',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '3mm',
+          marginTop: '2mm',
+        }}
+      >
+        <div className="short-report-cta">Get full 15-page report</div>
+        <div className="short-report-footer">© SkillTier — 1/1</div>
+      </div>
+    </div>
+  );
+}

--- a/report/types/report.ts
+++ b/report/types/report.ts
@@ -30,6 +30,8 @@ export interface ReportData {
   durationSec: number;
 }
 
+export type ReportDocT = ReportData;
+
 export interface DomainPageProps {
   domain: string;
   score: number;


### PR DESCRIPTION
## Summary
- create a reusable A4 short report layout that reuses existing report atoms and tokens
- add global report styling, demo route, and variant switch for the reports experience
- streamline long report demo print styles to rely on the shared CSS

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd78fde70c832fab2040975bb127e0